### PR TITLE
feat(trigger): Added dynamic triggering

### DIFF
--- a/QMigrate/plot/triggered_events.py
+++ b/QMigrate/plot/triggered_events.py
@@ -154,15 +154,11 @@ def triggered_events(events, start_time, end_time, output, marginal_window,
 
     if events is not None:
         if normalise_coalescence:
-            if isinstance(detection_threshold, float):
-                coa_norm.axhline(detection_threshold, c="g")
-            else:
-                coa_norm.plot(data["DT"], detection_threshold, "g-")
+            coa_norm.step(data["DT"], detection_threshold, where="mid", c="g",
+                          label="Detection threshold")
         else:
-            if isinstance(detection_threshold, float):
-                coa.axhline(detection_threshold, c="g")
-            else:
-                coa.plot(data["DT"], detection_threshold, "g-")
+            coa.step(data["DT"], detection_threshold, where="mid", c="g",
+                     label="Detection threshold")
 
         # Plotting the scatter of the earthquake locations
         xy.scatter(events["COA_X"], events["COA_Y"], 50, events["COA_V"])
@@ -196,7 +192,7 @@ def triggered_events(events, start_time, end_time, output, marginal_window,
     if savefig:
         subdir = "trigger/summaries"
         util.make_directories(output.run, subdir=subdir)
-        out = output.run / subdir / "{}_Trigger".format(output.name)
+        out = output.run / subdir / f"{output.name}_Trigger"
         out = str(out.with_suffix(".pdf"))
         plt.savefig(out)
     else:

--- a/example_running_scripts/trigger.py
+++ b/example_running_scripts/trigger.py
@@ -30,7 +30,14 @@ trig = qtrigger.Trigger(out_path, run_name, stations)
 trig.normalise_coalescence = True
 trig.marginal_window = 1.
 trig.minimum_repeat = 30.
+
+# Static threshold
 trig.detection_threshold = 1.75
+
+# Dynamic (Median Absolute Deviation) threshold
+# trig.detection_threshold = "dynamic"
+# trig.mad_window_length = 7200.
+# trig.mad_multiplier = 8.
 
 # --- Run trigger ---
 trig.trigger(start_time, end_time, savefig=False)


### PR DESCRIPTION
Added a feature to the existing trigger framework allowing a user to use
a dynamic trigger threshold. The dynamic threshold is defined as some
multiple of the Median Absolute Deviation (MAD) within a given chunk of
data. Essentially the algorithm is defining a threshold above which only
significant outliers will exist, which we treat as a seismic event.
This update has been tested on a small chunk of Borneo data and the
example trigger.py script has been updated to demonstrate how the dynamic
threshold can be toggled and configured.

For more details, read the wikipedia page on Median Absolute Deviation
https://en.wikipedia.org/wiki/Median_absolute_deviation.

Updated instances of <str>.format() to use f-strings (where appropriate)