### PR TITLE
fix(locate): Fix event location output

### DIFF
--- a/QMigrate/signal/scan.py
+++ b/QMigrate/signal/scan.py
@@ -1447,7 +1447,7 @@ class QuakeScan(DefaultQuakeScan):
                 msg += " with maximum coalescence value"
                 self.output.log(msg, self.log)
 
-            location = self.lut.coord2grid([[mxi, myi, mzi]], inverse=True)[0]
+            location = self.lut.index2coord([[mxi, myi, mzi]])[0]
 
             # Run check that spline location is within window
             if (abs(mx - mxi) > w2) or (abs(my - myi) > w2) or \
@@ -1456,13 +1456,13 @@ class QuakeScan(DefaultQuakeScan):
                 msg += "window !!!!\n\t\t\tGridded Location returned"
                 self.output.log(msg, self.log)
 
-                location = self.lut.coord2grid([[mx, my, mz]], inverse=True)[0]
+                location = self.lut.index2coord([[mx, my, mz]])[0]
         else:
             msg = "\t !!!! Spline error: interpolation window crosses edge of "
             msg += "grid !!!!\n\t\t\tGridded Location returned"
             self.output.log(msg, self.log)
 
-            location = self.lut.coord2grid([[mx, my, mz]], inverse=True)[0]
+            location = self.lut.index2coord([[mx, my, mz]])[0]
 
         return location
 


### PR DESCRIPTION
Fix the event location being written to the .event files. Previously it
was incorrectly using the transformation going from the Cartesian grid
space to the geographical space on the indices which corresponded to the
event location. Now correctly using the index2coord transformation!

Any events previously located using the version of QuakeMigrate on the
development branch will have incorrect event locations and will need to
be relocated.