### PR TITLE
chore: NLLoc read fixes and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dist/
 *.so
 .vscode/
 runs/
-lut/
+LUT/

--- a/QMigrate/signal/scan.py
+++ b/QMigrate/signal/scan.py
@@ -307,9 +307,11 @@ class QuakeScan(DefaultQuakeScan):
 
         """
 
-        # Convert times to UTCDateTime objects
+        # Convert times to UTCDateTime objects and check for muppetry
         start_time = UTCDateTime(start_time)
         end_time = UTCDateTime(end_time)
+        if start_time > end_time:
+            raise util.TimeSpanException
 
         msg = "=" * 110 + "\n"
         msg += "\tDETECT - Continuous Seismic Processing\n"
@@ -356,9 +358,11 @@ class QuakeScan(DefaultQuakeScan):
             raise RuntimeError("Must supply an input argument.")
 
         if not fname:
-            # Convert times to UTCDateTime objects
+            # Convert times to UTCDateTime objects and check for muppetry
             start_time = UTCDateTime(start_time)
             end_time = UTCDateTime(end_time)
+            if start_time > end_time:
+                raise util.TimeSpanException
 
         msg = "=" * 110 + "\n"
         msg += "\tLOCATE - Determining earthquake location and uncertainty\n"
@@ -490,7 +494,7 @@ class QuakeScan(DefaultQuakeScan):
         try:
             nsteps = int(np.ceil((end_time - start_time) / self.time_step))
         except AttributeError:
-            msg = "Error: Time step has not been specified"
+            msg = "Error: Time step has not been specified."
             self.output.log(msg, self.log)
             return
 

--- a/QMigrate/signal/trigger.py
+++ b/QMigrate/signal/trigger.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 import QMigrate.io as qio
 from QMigrate.plot import triggered_events
+import QMigrate.util as util
 
 
 def mad(x, scale=1.4826):
@@ -183,9 +184,11 @@ class Trigger:
 
         """
 
-        # Convert times to UTCDateTime objects
+        # Convert times to UTCDateTime objects and check for muppetry
         self.start_time = UTCDateTime(start_time)
         self.end_time = UTCDateTime(end_time)
+        if self.start_time > self.end_time:
+            raise util.TimeSpanException
         self.region = region
 
         if self.minimum_repeat < 2 * self.marginal_window:

--- a/QMigrate/util.py
+++ b/QMigrate/util.py
@@ -238,3 +238,16 @@ class PickerTypeError(Exception):
         msg = ("PickerTypeError: The PhasePicker object you have created does"
                "not inherit from the required base class - see manual.")
         super().__init__(msg)
+
+
+class TimeSpanException(Exception):
+    """
+    Custom exception to handle case when the user has submitted a start time
+    that is after the end time.
+
+    """
+
+    def __init__(self):
+        msg = ("TimeSpanException: The start time specified is after the end"
+               " time.")
+        super().__init__(msg)

--- a/examples/Icequake_Iceland/iceland_detect.py
+++ b/examples/Icequake_Iceland/iceland_detect.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Detect stage for the Iceland icequake example.
+
+"""
+
+import QMigrate.io as qio
+from QMigrate.lut import LUT
+from QMigrate.signal import QuakeScan
+from QMigrate.signal.onset import ClassicSTALTAOnset
+
+# --- i/o paths ---
+station_file = "./inputs/iceland_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run detect ---
+start_time = "2014-06-29T18:41:55.0"
+end_time = "2014-06-29T18:42:20.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Archive and set path structure ---
+data = qio.Archive(stations=stations, archive_path=data_in)
+data.path_structure(archive_format="YEAR/JD/*_STATION_*")
+
+# --- Load the LUT ---
+lut = LUT(lut_file=lut_out)
+
+# --- Create new Onset ---
+onset = ClassicSTALTAOnset()
+onset.p_bp_filter = [10, 125, 4]
+onset.s_bp_filter = [10, 125, 4]
+onset.p_onset_win = [0.01, 0.25]
+onset.s_onset_win = [0.05, 0.5]
+
+# --- Create new QuakeScan ---
+scan = QuakeScan(data, lut, onset=onset, output_path=out_path, run_name=run_name)
+
+# --- Set detect parameters ---
+scan.sampling_rate = 500
+scan.time_step = 0.75
+scan.n_cores = 12
+
+# --- Run detect ---
+scan.detect(start_time, end_time)

--- a/examples/Icequake_Iceland/iceland_locate.py
+++ b/examples/Icequake_Iceland/iceland_locate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Locate stage for the Iceland icequake example.
+
+"""
+
+
+import QMigrate.io as qio
+from QMigrate.lut import LUT
+from QMigrate.signal import QuakeScan
+from QMigrate.signal.onset import CentredSTALTAOnset
+from QMigrate.signal.pick import GaussianPicker
+
+# --- i/o paths ---
+station_file = "./inputs/iceland_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run locate ---
+start_time = "2014-06-29T18:41:55.0"
+end_time = "2014-06-29T18:42:20.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Archive and set path structure ---
+data = qio.Archive(stations=stations, archive_path=data_in)
+data.path_structure(archive_format="YEAR/JD/*_STATION_*")
+
+# --- Load the LUT ---
+lut = LUT(lut_file=lut_out)
+
+# --- Create new Onset ---
+onset = CentredSTALTAOnset()
+onset.p_bp_filter = [10, 125, 4]
+onset.s_bp_filter = [10, 125, 4]
+onset.p_onset_win = [0.01, 0.25]
+onset.s_onset_win = [0.05, 0.5]
+
+# --- Create new PhasePicker ---
+picker = GaussianPicker(onset=onset)
+picker.marginal_window = 2.75
+picker.plot_phase_picks = True
+
+# --- Create new QuakeScan ---
+scan = QuakeScan(data, lut, onset=onset, picker=picker,
+                 output_path=out_path, run_name=run_name, log=True)
+
+# --- Set locate parameters ---
+# For a complete list of parameters and guidance on how to choose them, please
+# see the manual and read the docs.
+scan.marginal_window = 2.75
+scan.n_cores = 12
+scan.sampling_rate = 500
+
+# --- Toggle plotting options ---
+scan.plot_event_video = False
+scan.plot_event_summary = True
+scan.plot_station_traces = True
+
+# --- Toggle writing of waveforms ---
+scan.write_cut_waveforms = True
+
+# --- Run locate ---
+scan.locate(start_time=start_time, end_time=end_time)

--- a/examples/Icequake_Iceland/iceland_lut.py
+++ b/examples/Icequake_Iceland/iceland_lut.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Creation of LUT for the Iceland icequake example.
+
+"""
+
+from pyproj import Proj
+
+import QMigrate.io as qio
+import QMigrate.lut as qlut
+
+station_file = "./inputs/iceland_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Read in the station information file ---
+stations = qio.stations(station_file)
+
+# --- Define projections ---
+cproj = Proj(proj="longlat", ellps="WGS84", datum="WGS84", no_defs=True)
+gproj = Proj(proj="lcc", lon_0=-17.224, lat_0=64.328, lat_1=64.32, lat_2=64.335,
+             datum="WGS84", ellps="WGS84", units="m", no_defs=True)
+
+# --- Create new LUT ---
+# Cell count (x,y,z); cell size (x,y,z in metres)
+lut = qlut.LUT(ll_corner=[-17.24363934275664, 64.31947715407385, -1390.],
+               ur_corner=[-17.204348515198255, 64.3365202025144, 1390],
+               cell_size=[100., 100., 20.], grid_proj=gproj, coord_proj=cproj)
+
+# --- Homogeneous LUT generation ---
+vp = 3630
+vs = 1833
+qlut.compute(lut, stations, method="homogeneous", vp=vp, vs=vs)
+
+# --- Save LUT ---
+lut.save(lut_out)

--- a/examples/Icequake_Iceland/iceland_trigger.py
+++ b/examples/Icequake_Iceland/iceland_trigger.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Trigger stage for the Iceland icequake example.
+
+"""
+
+import QMigrate.io as qio
+from QMigrate.signal import Trigger
+
+# --- i/o paths ---
+station_file = "./inputs/iceland_stations.txt"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run trigger ---
+start_time = "2014-06-29T18:41:55.0"
+end_time = "2014-06-29T18:42:20.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Trigger ---
+trig = Trigger(out_path, run_name, stations)
+
+# --- Set trigger parameters ---
+# For a complete list of parameters and guidance on how to choose them, please
+# see the manual and read the docs.
+trig.marginal_window = 2.75
+trig.minimum_repeat = 6.
+trig.normalise_coalescence = True
+
+# --- Static threshold ---
+trig.detection_threshold = 1.8
+
+# --- Dynamic (Median Absolute Deviation) threshold ---
+# trig.detection_threshold = "dynamic"
+# trig.mad_window_length = 7200.
+# trig.mad_multiplier = 8.
+
+# --- Run trigger ---
+trig.trigger(start_time, end_time, savefig=False)

--- a/examples/Icequake_Iceland/icequakes_iceland.ipynb
+++ b/examples/Icequake_Iceland/icequakes_iceland.ipynb
@@ -55,7 +55,7 @@
     "# --- i/o paths ---\n",
     "station_file = \"./inputs/iceland_stations.txt\"\n",
     "data_in = \"./inputs/mSEED\"\n",
-    "lut_out = \"./outputs/lut/icequake.LUT\"\n",
+    "lut_out = \"./outputs/LUT/icequake.LUT\"\n",
     "out_path = \"./outputs/runs\"\n",
     "run_name = \"icequake_example\""
    ]

--- a/examples/Icequake_Rutford/icequakes_rutford.ipynb
+++ b/examples/Icequake_Rutford/icequakes_rutford.ipynb
@@ -55,7 +55,7 @@
     "# --- i/o paths ---\n",
     "station_file = \"./inputs/rutford_stations.txt\"\n",
     "data_in = \"./inputs/mSEED\"\n",
-    "lut_out = \"./outputs/lut/icequake.LUT\"\n",
+    "lut_out = \"./outputs/LUT/icequake.LUT\"\n",
     "out_path = \"./outputs/runs\"\n",
     "run_name = \"icequake_example\""
    ]

--- a/examples/Icequake_Rutford/rutford_detect.py
+++ b/examples/Icequake_Rutford/rutford_detect.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Detect stage for the Rutford icequake example.
+
+"""
+
+import QMigrate.io as qio
+from QMigrate.lut import LUT
+from QMigrate.signal import QuakeScan
+from QMigrate.signal.onset import ClassicSTALTAOnset
+
+station_file = "./inputs/rutford_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run detect ---
+start_time = "2009-01-21T04:00:05.0"
+end_time = "2009-01-21T04:00:15.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Archive and set path structure ---
+data = qio.Archive(stations=stations, archive_path=data_in)
+data.path_structure(archive_format="YEAR/JD/*_STATION_*")
+
+# --- Load the LUT ---
+lut = LUT(lut_file=lut_out)
+
+# --- Create new Onset ---
+onset = ClassicSTALTAOnset()
+onset.p_bp_filter = [20, 200, 4]
+onset.s_bp_filter = [10, 125, 4]
+onset.p_onset_win = [0.01, 0.25]
+onset.s_onset_win = [0.05, 0.5]
+
+# --- Create new QuakeScan ---
+scan = QuakeScan(data, lut, onset=onset, output_path=out_path, run_name=run_name)
+
+# --- Set detect parameters ---
+scan.sampling_rate = 1000
+scan.time_step = 0.75
+scan.n_cores = 12
+
+# --- Run detect ---
+scan.detect(start_time, end_time)

--- a/examples/Icequake_Rutford/rutford_locate.py
+++ b/examples/Icequake_Rutford/rutford_locate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Locate stage for the Rutford icequake example.
+
+"""
+
+
+import QMigrate.io as qio
+from QMigrate.lut import LUT
+from QMigrate.signal import QuakeScan
+from QMigrate.signal.onset import CentredSTALTAOnset
+from QMigrate.signal.pick import GaussianPicker
+
+# --- i/o paths ---
+station_file = "./inputs/rutford_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run locate ---
+start_time = "2009-01-21T04:00:05.0"
+end_time = "2009-01-21T04:00:15.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Archive and set path structure ---
+data = qio.Archive(stations=stations, archive_path=data_in)
+data.path_structure(archive_format="YEAR/JD/*_STATION_*")
+
+# --- Load the LUT ---
+lut = LUT(lut_file=lut_out)
+
+# --- Create new Onset ---
+onset = CentredSTALTAOnset()
+onset.p_bp_filter = [20, 200, 4]
+onset.s_bp_filter = [10, 125, 4]
+onset.p_onset_win = [0.01, 0.25]
+onset.s_onset_win = [0.05, 0.5]
+
+# --- Create new PhasePicker ---
+picker = GaussianPicker(onset=onset)
+picker.marginal_window = 0.1
+picker.plot_phase_picks = True
+
+# --- Create new QuakeScan ---
+scan = QuakeScan(data, lut, onset=onset, picker=picker,
+                 output_path=out_path, run_name=run_name, log=True)
+
+# --- Set locate parameters ---
+# For a complete list of parameters and guidance on how to choose them, please
+# see the manual and read the docs.
+scan.marginal_window = 0.1
+scan.n_cores = 12
+scan.sampling_rate = 1000
+
+# --- Toggle plotting options ---
+scan.plot_event_video = False
+scan.plot_event_summary = True
+scan.plot_station_traces = True
+
+# --- Toggle writing of waveforms ---
+scan.write_cut_waveforms = True
+
+# --- Run locate ---
+scan.locate(start_time=start_time, end_time=end_time)

--- a/examples/Icequake_Rutford/rutford_lut.py
+++ b/examples/Icequake_Rutford/rutford_lut.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Creation of LUT for the Rutford icequake example.
+
+"""
+
+from pyproj import Proj
+
+import QMigrate.io as qio
+import QMigrate.lut as qlut
+
+station_file = "./inputs/rutford_stations.txt"
+data_in = "./inputs/mSEED"
+lut_out = "./outputs/LUT/icequake.LUT"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Read in the station information file ---
+stations = qio.stations(station_file)
+
+# --- Define projections ---
+cproj = Proj(proj="longlat", ellps="WGS84", datum="WGS84", no_defs=True)
+gproj = Proj(proj="lcc", lon_0=-83.932, lat_0=-78.144, lat_1=-78.1, lat_2=-77.9,
+             datum="WGS84", ellps="WGS84", units="m", no_defs=True)
+
+# --- Create new LUT ---
+# Cell count (x,y,z); cell size (x,y,z in metres)
+lut = qlut.LUT(ll_corner=[-84.14853353566141, -78.18825429331356, -350.],
+               ur_corner=[-83.71921885073093, -78.10003166259442, 3550],
+               cell_size=[100., 100., 100.], grid_proj=gproj, coord_proj=cproj)
+
+# --- Homogeneous LUT generation ---
+vp = 3841
+vs = 1970
+qlut.compute(lut, stations, method="homogeneous", vp=vp, vs=vs)
+
+# --- Save LUT ---
+lut.save(lut_out)

--- a/examples/Icequake_Rutford/rutford_trigger.py
+++ b/examples/Icequake_Rutford/rutford_trigger.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Trigger stage for the Rutford icequake example.
+
+"""
+
+import QMigrate.io as qio
+from QMigrate.signal import Trigger
+
+# --- i/o paths ---
+station_file = "./inputs/rutford_stations.txt"
+out_path = "./outputs/runs"
+run_name = "icequake_example"
+
+# --- Set time period over which to run trigger ---
+start_time = "2009-01-21T04:00:05.0"
+end_time = "2009-01-21T04:00:15.0"
+
+# --- Read in station file ---
+stations = qio.stations(station_file)
+
+# --- Create new Trigger ---
+trig = Trigger(out_path, run_name, stations)
+
+# --- Set trigger parameters ---
+# For a complete list of parameters and guidance on how to choose them, please
+# see the manual and read the docs.
+trig.marginal_window = 0.1
+trig.minimum_repeat = 0.5
+trig.normalise_coalescence = True
+
+# --- Static threshold ---
+trig.detection_threshold = 2.75
+
+# --- Dynamic (Median Absolute Deviation) threshold ---
+# trig.detection_threshold = "dynamic"
+# trig.mad_window_length = 7200.
+# trig.mad_multiplier = 8.
+
+# --- Run trigger ---
+trig.trigger(start_time, end_time, savefig=False)


### PR DESCRIPTION
Made multiple fixes as a result of feedback from a user, namely with the
function that reads NLLoc traveltime tables:

Fixed projections used in NLLoc read function. Now correctly passes the
parameters needed for the lambert conformal conic projection and the
transverse mercator projection.

Improved code readability in the create_lut.py file, primarily by using
fstrings.

Added a catch for if a user tries to use nonsensical start/end times
(i.e. a start time after the end time).