### PR TITLE
refactor: Finalise interface abstraction for STALTAOnset and GaussianPicker

### DIFF
--- a/QMigrate/signal/onset/onset.py
+++ b/QMigrate/signal/onset/onset.py
@@ -78,6 +78,14 @@ class Onset(ABC):
 
         return pre_pad, post_pad
 
+    def gaussian_halfwidth(self, phase):
+        """Method stub for Gaussian half-width estimate."""
+
+        msg = ("In order to use the GaussianPicker module with a custom Onset,"
+               " you need to provide a 'gaussian_halfwidth' method.")
+
+        raise AttributeError(msg)
+
     @abstractmethod
     def calculate_onsets(self):
         """Method stub for calculation of onset functions."""

--- a/QMigrate/signal/onset/staltaonset.py
+++ b/QMigrate/signal/onset/staltaonset.py
@@ -358,6 +358,25 @@ class STALTAOnset(Onset):
 
         return s_onset, filt_sige, filt_sign
 
+    def gaussian_halfwidth(self, phase):
+        """
+        Return the phase-appropriate Gaussian half-width estimate based on the
+        short-term average window length.
+
+        Parameters
+        ----------
+        phase : {'P', 'S'}
+            Seismic phase for which to serve the estimate.
+
+        """
+
+        if phase == "P":
+            sta_window = self.p_onset_win[0]
+        elif phase == "S":
+            sta_window = self.s_onset_win[0]
+
+        return (sta_window * self.sampling_rate / 2)
+
     @property
     def pre_pad(self):
         """Pre-pad is determined as a function of the onset windows"""

--- a/QMigrate/signal/pick/gaussianpicker.py
+++ b/QMigrate/signal/pick/gaussianpicker.py
@@ -257,11 +257,9 @@ class GaussianPicker(PhasePicker):
 
         # Setting parameters depending on the phase
         if phase == "P":
-            sta_winlen = self.onset.p_onset_win[0]
             win_min = P_idxmin
             win_max = P_idxmax
         if phase == "S":
-            sta_winlen = self.onset.s_onset_win[0]
             win_min = S_idxmin
             win_max = S_idxmax
 
@@ -319,7 +317,7 @@ class GaussianPicker(PhasePicker):
 
             # Initial guess for gaussian half-width based on onset function
             # STA window length
-            data_half_range = int(sta_winlen * self.sampling_rate / 2)
+            data_half_range = self.onset.gaussian_halfwidth(phase)
 
             # Select data to fit the gaussian to
             x_data = np.arange(gau_idxmin, gau_idxmax, dtype=float)


### PR DESCRIPTION

<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Cut the final explicit tie between STALTAOnset and GaussianPicker - the
interface is now fully abstracted such that users can use the GaussianPicker
module with custom Onsets.

- Added a gaussian_halfwidth method to the Onset base class that will raise an
error if the user tries to use the GaussianPicker without implementing that
part of the interface.
- Added a gaussian_halfwidth method to the STALTAOnset class that takes a
phase argument and returns the phase-relevant short-term average window
length (in terms of samples).

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.

### Final checklist
- [x] `develop` base branch selected?
- [x] All tests still pass.
- [x] Any new or changed features are fully documented.