### PR TITLE
[FIX] gaussianpicker.py - Fix check that picktime is inside picking window

### DIFF
--- a/quakemigrate/signal/pick/gaussianpicker.py
+++ b/quakemigrate/signal/pick/gaussianpicker.py
@@ -272,6 +272,8 @@ class GaussianPicker(PhasePicker):
             win_min = S_idxmin
             win_max = S_idxmax
 
+        logging.debug(f"Win_min = {win_min} ; Win_max = {win_max}")
+
         # Find index of maximum value of onset function in the appropriate
         # pick window
         max_onset = np.argmax(onset[win_min:win_max]) + win_min
@@ -323,6 +325,8 @@ class GaussianPicker(PhasePicker):
             # Add one data point below the threshold at each end of this period
             gau_idxmin = exceedence[tmp][0] + win_min - 1
             gau_idxmax = exceedence[tmp][-1] + win_min + 2
+            logging.debug(f"gau_idxmin = {gau_idxmin} ; "
+                          f"gau_idxmax = {gau_idxmax}")
 
             # Initial guess for gaussian half-width based on onset function
             # STA window length
@@ -360,7 +364,7 @@ class GaussianPicker(PhasePicker):
                 sigma = np.absolute(popt[2])
 
                 # Check pick mean is within the pick window.
-                if not gau_idxmin < popt[1] * self.sampling_rate < gau_idxmax:
+                if not win_min < popt[1] * self.sampling_rate < win_max:
                     gaussian_fit = self.DEFAULT_GAUSSIAN_FIT
                     gaussian_fit["PickThreshold"] = threshold
                     sigma = -1


### PR DESCRIPTION
## What is the purpose of this Pull Request? 
This PR fixes the bug described in https://github.com/QuakeMigrate/QuakeMigrate/issues/98 where the S / P picks returned by the gaussianpicker can be outside the pick windows, and therefore potentially in the wrong order.

A check for this was implemented previously in https://github.com/QuakeMigrate/QuakeMigrate/commit/da3b907ea6a0ee1f695700c7430ace779f63cd0a , but using the wrong index for the comparison.

### Relevant Issues
https://github.com/QuakeMigrate/QuakeMigrate/issues/98

## Test cases
- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 18.04

### Final checklist
- [x] `develop` base branch selected?
- [x] All tests still pass.
- [x] Any new or changed features are fully documented.