### PR TITLE
fix(locate): catch reading triggered events issue

### DIFF
--- a/quakemigrate/io/triggered_events.py
+++ b/quakemigrate/io/triggered_events.py
@@ -71,6 +71,10 @@ def read_triggered_events(run, **kwargs):
         events = events[(events["CoaTime"] >= starttime) &
                         (events["CoaTime"] <= endtime)]
 
+    if len(events) == 0:
+        logging.info("\n\t    No triggered events found! Check your trigger "
+                     "output files.\n")
+
     return events.reset_index()
 
 

--- a/quakemigrate/io/triggered_events.py
+++ b/quakemigrate/io/triggered_events.py
@@ -60,6 +60,8 @@ def read_triggered_events(run, **kwargs):
             else:
                 logging.info(f"\n\t    Cannot find file: {fstem}")
             readstart += 86400
+        if len(trigger_files) == 0:
+            raise util.NoTriggerFilesFound
         events = pd.concat((pd.read_csv(f) for f in trigger_files),
                            ignore_index=True)
 

--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -549,6 +549,20 @@ class MagsTypeError(Exception):
         super().__init__(msg)
 
 
+class NoTriggerFilesFound(Exception):
+    """
+    Custom exception to handle case when no trigger files are found during
+    locate. This can occur for a number of reasons - an entirely invalid time
+    period was used
+
+    """
+
+    def __init__(self):
+        msg = ("NoTriggerFilesFound: Double check you have supplied a valid "
+               "run name and a time period for which you have run detect.")
+        super().__init__(msg)
+
+
 class ResponseNotFoundError(Exception):
     """
     Custom exception to handle the case where the provided response inventory

--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -552,8 +552,10 @@ class MagsTypeError(Exception):
 class NoTriggerFilesFound(Exception):
     """
     Custom exception to handle case when no trigger files are found during
-    locate. This can occur for a number of reasons - an entirely invalid time
-    period was used
+    locate. This can occur for one of two reasons - an entirely invalid time
+    period was used (i.e. one that does not overlap at all with a period of
+    time for which there exists TriggeredEvents.csv files) or an invalid run
+    name was provided.
 
     """
 


### PR DESCRIPTION

<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Catch and handle (by means of an explicit error message) an issue whereby the user might set an invalid run name or time period for locate, but the script would crash with a fairly impenetrable error.

All previous behaviour identical, now simply checks if any suitable triggered events files were found during the while loop. If not, raise the error. Perhaps it would be worth catching this and printing something neater before exiting the script, but the net effect is the same.

## Test cases
Tested by providing an invalid run name and an invalid time period. An invalid time period is one for which there is no overlap with the time period for which there exists TriggeredEvents.csv files.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 20.04

### Final checklist
- [x] All tests still pass.
- [x] Any new or changed features are fully documented.