### PR TITLE
feat: added more advanced station naming

### DIFF
--- a/quakemigrate/io/core.py
+++ b/quakemigrate/io/core.py
@@ -86,14 +86,29 @@ def read_stations(station_file, **kwargs):
 
     stn_data = pd.read_csv(station_file, **kwargs)
 
-    if ("Latitude" or "Longitude" or "Elevation" or "Name") \
+    if ("Latitude" or "Longitude" or "Elevation" or "Station") \
        not in stn_data.columns:
         raise util.StationFileHeaderException
 
     stn_data["Elevation"] = stn_data["Elevation"].apply(lambda x: -1*x)
 
+    if not 'Network' in stn_data.columns:
+        stn_data["Network"] = "*"
+    if not 'Location' in stn_data.columns:
+        stn_data["Location"] = "*"
+    if not 'Channel' in stn_data.columns:
+        stn_data["Channel"] = "*"
+    stn_data['Name'] = stn_data["Network"] + "." + \
+                        stn_data["Station"]
+
     # Ensure station names are strings
+    stn_data = stn_data.astype({"Network": "str"})
+    stn_data = stn_data.astype({"Station": "str"})
+    stn_data = stn_data.astype({"Location": "str"})
+    stn_data = stn_data.astype({"Channel": "str"})
     stn_data = stn_data.astype({"Name": "str"})
+
+    stn_data['Name'] = [s.replace('*', '') for s in stn_data['Name']]
 
     return stn_data
 

--- a/quakemigrate/lut/create_lut.py
+++ b/quakemigrate/lut/create_lut.py
@@ -378,6 +378,7 @@ def _compute_1d_sweep(lut, phase, vmodel, **kwargs):
     (cwd / "model").mkdir(exist_ok=True)
 
     for i, station in enumerate(lut.station_data["Name"].values):
+        # station = station.replace('*', '')
         logging.info(f"\t\t...running NonLinLoc - station: {station:5s} - "
                      f"{i+1} of {stations_xyz.shape[0]}")
 
@@ -405,7 +406,7 @@ def _compute_1d_sweep(lut, phase, vmodel, **kwargs):
         to_read = cwd / "time" / f"layer.{phase}.{station}.time"
         gridspec, _, traveltimes = _read_nlloc(to_read, ignore_proj=True)
 
-        lut.traveltimes.setdefault(station, {}).update(
+        lut.traveltimes.setdefault(lut.station_data["Name"][i], {}).update(
             {phase: _bilinear_interpolate(np.c_[distances, depths],
                                           gridspec[1, 1:],
                                           gridspec[2, 1:],

--- a/quakemigrate/plot/event.py
+++ b/quakemigrate/plot/event.py
@@ -191,7 +191,7 @@ def _plot_waveform_gather(ax, lut, event, idx):
     ax.set_ylim([0, max(range_order)+2])
     ax.xaxis.set_major_formatter(util.DateFormatter("%H:%M:%S.{ms}", 2))
     ax.yaxis.set_ticks(range_order)
-    ax.yaxis.set_ticklabels(event.data.stations, fontsize=14)
+    ax.yaxis.set_ticklabels(event.data.stations['Name'], fontsize=14)
 
 
 def _plot_coalescence_trace(ax, event):

--- a/quakemigrate/signal/local_mag/amplitude.py
+++ b/quakemigrate/signal/local_mag/amplitude.py
@@ -262,7 +262,10 @@ class Amplitude:
 
         # Loop through stations, calculating amplitude info
         for i, station_data in lut.station_data.iterrows():
-            station = station_data["Name"]
+            network = station_data["Network"]
+            station = station_data["Station"]
+            location = station_data["Location"]
+            channel = station_data["Channel"]
 
             epi_dist, z_dist = self._get_distances(ev_loc, station_data,
                                                    lut.unit_conversion_factor)
@@ -274,7 +277,10 @@ class Amplitude:
                              np.nan, np.nan, np.nan, np.nan, False]
 
             # Read in raw waveforms
-            st = event.data.raw_waveforms.select(station=station)
+            st = event.data.raw_waveforms.select(network=network,
+                                                 station=station,
+                                                 location=location,
+                                                 channel=channel)
 
             for j, comp in enumerate(["E", "N", "Z"]): # NOTE: Will not work with 1, 2 (etc.)
                 amps = amps_template.copy()
@@ -287,7 +293,7 @@ class Amplitude:
                     and tr[0].stats.endtime > (tr_end - tr[0].stats.delta):
                     tr = tr[0]
                 else:
-                    amps[0] = f".{station}..{comp}"
+                    amps[0] = f"{network}.{station}.{location}.{comp}"
                     amplitudes.loc[i*3+j] = amps
                     continue
 

--- a/quakemigrate/signal/pickers/gaussian.py
+++ b/quakemigrate/signal/pickers/gaussian.py
@@ -464,7 +464,8 @@ class GaussianPicker(PhasePicker):
                 ax.legend(fontsize=14)
 
             fstem = f"{event.uid}_{station}"
-            file = (fpath / fstem).with_suffix(".pdf")
+            # file = (fpath / fstem).with_suffix(".pdf")
+            file = fpath / (fstem + '.pdf')
             plt.savefig(file)
             plt.close(fig)
 


### PR DESCRIPTION
	Added a feature such that stations can be defined in the stations
input file using their full ids (i.e. network, station, location, channel).
This improves the ability for QM users to select station and channel
combinations from larger data archives.

The only significant change to the input file is that users should define
"Station" at minimum in their station input files. QM will then assemble a
naming string using wildards. Users can also add addition columns ("Network",
"Location" and "Channel") which can include regex expressions.

As part of this feature I have removed most of the default naming schemes
(leaving only SeisComp3). Novice users will struggle to find find where
these are defined and I find it difficult to remember the string syntax. I
suggest users instead use the format strings functionality which is more
flexible and easier to understand. But as always, this can be put back in if
necessary

I have tested this on the Reykjanes dataset and it seems to work as expected.