### PR TITLE
[FIX]: Fix resampling/upsampling bug; more explicit handling of data timing.

### DIFF
--- a/quakemigrate/io/data.py
+++ b/quakemigrate/io/data.py
@@ -396,7 +396,8 @@ class WaveformData:
 
     def check_availability(self, st, all_channels=False, n_channels=None,
                            allow_gaps=False, full_timespan=True,
-                           check_sampling_rate=False, sampling_rate=None):
+                           check_sampling_rate=False, sampling_rate=None,
+                           check_start_end_times=False):
         """
         Check waveform availability against data quality criteria.
 
@@ -421,12 +422,17 @@ class WaveformData:
             Whether to allow gaps.
         full_timespan : bool, optional
             Whether to ensure the data covers the entire timespan requested;
-            note that this implicitly requires that there be no gaps.
+            note that this implicitly requires that there be no gaps. Checks
+            the number of samples in the trace, not the start and end times;
+            for that see `check_start_end_times`.
         check_sampling_rate : bool, optional
             Check that all channels are at the desired sampling rate.
         sampling_rate : float, optional
             If `check_sampling_rate=True`, this argument is required to specify
             the sampling rate that the data should be at.
+        check_start_end_times : bool, optional
+            A stricter alternative to `full_timespan`; checks that the first
+            and last sample of the trace have exactly the requested timestamps.
 
         Returns
         -------
@@ -486,6 +492,14 @@ class WaveformData:
                         continue
                     elif st_id[0].stats.npts < n_samples:
                         continue
+                # Check start and end times of trace are exactly correct
+                if check_start_end_times:
+                    if len(st_id) > 1:
+                        continue
+                    elif st_id[0].stats.starttime != self.starttime or \
+                        st_id[0].stats.endtime != self.endtime:
+                        continue
+
                 # If passed all tests, set availability to 1
                 availability[tr_id] = 1
 

--- a/quakemigrate/io/data.py
+++ b/quakemigrate/io/data.py
@@ -207,7 +207,8 @@ class Archive:
                 try:
                     read_start = starttime - pre_pad
                     read_end = endtime + post_pad
-                    st += read(file, starttime=read_start, endtime=read_end)
+                    st += read(file, starttime=read_start, endtime=read_end,
+                               nearest_sample=True)
                 except TypeError:
                     logging.info(f"File not compatible with ObsPy - {file}")
                     continue
@@ -230,7 +231,8 @@ class Archive:
             if pre_pad != 0. or post_pad != 0.:
                 # Trim data between start and end time
                 for tr in st:
-                    tr.trim(starttime=starttime, endtime=endtime)
+                    tr.trim(starttime=starttime, endtime=endtime,
+                            nearest_sample=True)
                     if not bool(tr):
                         st.remove(tr)
 
@@ -308,9 +310,9 @@ class WaveformData:
     Parameters
     ----------
     starttime : `obspy.UTCDateTime` object
-        Timestamp of first sample of waveform data.
+        Timestamp of first sample of waveform data requested from the archive.
     endtime : `obspy.UTCDateTime` object
-        Timestamp of last sample of waveform data.
+        Timestamp of last sample of waveform data requested from the archive.
     stations : `pandas.Series` object, optional
         Series object containing station names.
     read_all_stations : bool, optional
@@ -335,9 +337,9 @@ class WaveformData:
     Attributes
     ----------
     starttime : `obspy.UTCDateTime` object
-        Timestamp of first sample of waveform data.
+        Timestamp of first sample of waveform data requested from the archive.
     endtime : `obspy.UTCDateTime` object
-        Timestamp of last sample of waveform data.
+        Timestamp of last sample of waveform data requested from the archive.
     stations : `pandas.Series` object
         Series object containing station names.
     read_all_stations : bool

--- a/quakemigrate/io/data.py
+++ b/quakemigrate/io/data.py
@@ -77,6 +77,12 @@ class Archive:
         Factor by which to upsample the data to enable it to be decimated to
         the desired sampling rate, e.g. 40Hz -> 50Hz requires upfactor = 5.
         See :func:`~quakemigrate.util.resample`
+    interpolate : bool, optional
+        If data is timestamped "off-sample" (i.e. a non-integer number of
+        samples after midnight), whether to interpolate the data to apply the
+        necessary correction. Default behaviour is to just alter the metadata,
+        resulting in a sub-sample timing offset. See
+        :func:`~quakemigrate.util.shift_to_sample`.
 
     Methods
     -------
@@ -102,6 +108,7 @@ class Archive:
         self.response_inv = kwargs.get("response_inv")
         self.resample = kwargs.get("resample", False)
         self.upfactor = kwargs.get("upfactor")
+        self.interpolate = kwargs.get("interpolate", False)
 
     def __str__(self):
         """Returns a short summary string of the Archive object."""
@@ -219,6 +226,12 @@ class Archive:
 
             # Make copy of raw waveforms to output if requested
             data.raw_waveforms = st.copy()
+
+            # Ensure data is timestamped "on-sample" (i.e. an integer number
+            # of samples after midnight). Otherwise the data will be implicitly
+            # shifted when it is used to calculate the onset function /
+            # migrated.
+            st = util.shift_to_sample(st, interpolate=self.interpolate)
 
             if self.read_all_stations:
                # Re-populate st with only stations in station file

--- a/quakemigrate/signal/onsets/stalta.py
+++ b/quakemigrate/signal/onsets/stalta.py
@@ -327,7 +327,9 @@ class STALTAOnset(Onset):
                     all_channels=self.all_channels,
                     n_channels=self.channel_counts[phase],
                     allow_gaps=self.allow_gaps,
-                    full_timespan=self.full_timespan)
+                    full_timespan=self.full_timespan,
+                    check_sampling_rate=True,
+                    sampling_rate=self.sampling_rate)
                 availability[f"{station}_{phase}"] = available
 
                 # If no data available, skip
@@ -357,7 +359,7 @@ class STALTAOnset(Onset):
                     # Pad start/end
                     waveforms.trim(starttime=data.starttime,
                                    endtime=data.endtime, pad=True,
-                                   fill_value=tiny)
+                                   fill_value=tiny, nearest_sample=True)
 
                 # Calculate onset and add to WaveForm data object; add filtered
                 # waveforms that have passed the availability check to


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Previously when data was upsampled during resampling (e.g. if going from raw data sampling rate of 40 Hz to an onset function sampling rate of 50 Hz), no check was made that the start and endtimes of the data read from the archive exactly matched the start and endtimes requested (which are calculated assuming the data being read is at the onset function sampling rate, or a multiple if it). In many cases this would not be the case, leading to this data being needlessly discarded.

In this PR this bug is fixed, along with:
* Adding a couple more options to `data.check_availability()` to explicitly check that the data is at the correct sampling rate, and an option to more strictly check it covers the requested timespan (by checking the start and endtimes, not just the number of samples).
* Added a function to explicitly handle "off-sample" timestamped data. See commit https://github.com/QuakeMigrate/QuakeMigrate/commit/b2aafe926d69b231eb172ccc1e8bedfb24e83cd5 for a full explanation. Previously this was implicitly shifted - now there is an explicit option to either continue this previous behaviour, or interpolate the data to shift the sample timestamps without affecting the timing.
* Making clearer when we are using `nearest_sample=True` for obspy.read(), obspy.stream.trim() and why

## Test cases
* The resampling/upsampling fix has been tested with data which was previously affected by this bug (40 Hz data being resampled to 50 Hz onset function sampling rate) and shows all tests now pass as expected. Plus a thorough inspection of the new debug messages added to the code.
* The shift_to_sample function has been tested by artificially shifting the timestamps of 50 Hz data by 0.003, 0.01 and 0.011 seconds using `interpolate=False`. All tests produce the expected results.
* The previous test was also run with a time shift of 0.011 s and `interpolate=True` and produced the expected results compared to the non-shifted data and to the shifted data run with `interpolate=False`. This was primarily compared by looking at the difference in the pick times.


- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 18.04

### Final checklist
- [x] `develop` base branch selected?
- [x] All tests still pass.
- [x] Any new or changed features are fully documented.