### PR TITLE
FIX: Minor bug fixes

### DIFF
--- a/quakemigrate/io/cut_waveforms.py
+++ b/quakemigrate/io/cut_waveforms.py
@@ -38,17 +38,16 @@ warnings.filterwarnings("ignore", message=("The encoding specified in "
 
 @util.timeit("info")
 def write_cut_waveforms(run, event, file_format, pre_cut=0., post_cut=0.,
-                        waveform_type="raw",
-                        units="displacement"):
+                        waveform_type="raw", units="displacement"):
     """
-    Output cut waveform data as a waveform file -- defaults to mSEED.
+    Output cut waveform data as a waveform file -- defaults to miniSEED format.
 
     Parameters
     ----------
-    run : :class:`~quakemigrate.io.Run` object
+    run : :class:`~quakemigrate.io.core.Run` object
         Light class encapsulating i/o path information for a given run.
-    event : :class:`~quakemigrate.io.Event` object
-        Light class encapsulating signal, onset, and location information for a
+    event : :class:`~quakemigrate.io.event.Event` object
+        Light class encapsulating waveform data and location information for a
         given event.
     file_format : str, optional
         File format to write waveform data to. Options are all file formats
@@ -56,16 +55,22 @@ def write_cut_waveforms(run, event, file_format, pre_cut=0., post_cut=0.,
         "GSE2"
     pre_cut : float or None, optional
         Specify how long before the event origin time to cut the waveform
-        data from
+        data from.
     post_cut : float or None, optional
         Specify how long after the event origin time to cut the waveform
-        data to
+        data to.
     waveform_type : {"raw", "real", "wa"}, optional
         Whether to output raw, real or Wood-Anderson simulated waveforms.
         Default: "raw"
     units : {"displacement", "velocity"}, optional
         Whether to output displacement waveforms or velocity waveforms for
         real / Wood-Anderson corrected traces. Default: displacement
+
+    Raises
+    ------
+    AttributeError
+        If real or wa waveforms are requested and no response inventory has
+        been provided.
 
     """
 
@@ -77,13 +82,18 @@ def write_cut_waveforms(run, event, file_format, pre_cut=0., post_cut=0.,
 
     st = event.data.raw_waveforms
 
-    # "If pre_cut" catches both 0. and None
+    # "if pre_cut" catches both 0. and None
     if pre_cut:
         for tr in st.traces:
             tr.trim(starttime=event.otime - pre_cut)
     if post_cut:
         for tr in st.traces:
             tr.trim(endtime=event.otime + post_cut)
+
+    # Remove empty traces
+    for tr in st:
+        if not bool(tr):
+            st.remove(tr)
 
     if waveform_type == "real" or waveform_type == "wa":
         if waveform_type == "real" and \
@@ -97,34 +107,39 @@ def write_cut_waveforms(run, event, file_format, pre_cut=0., post_cut=0.,
         else:
             try:
                 st = get_waveforms(st, event, waveform_type, units)
-            except util.ResponseNotFoundError as e:
-                logging.warning(e)
-                return
+            except AttributeError as e:
+                raise AttributeError("To output real or Wood-Anderson"
+                                     " cut waveforms you must supply an "
+                                     "instrument response inventory.") from e
 
-    write_waveforms(st, fpath, fstem, file_format)
+    if bool(st):
+        write_waveforms(st, fpath, fstem, file_format)
+    else:
+        logging.info(f"\t\tNo {waveform_type} cut waveform data for event "
+                     f"{event.uid} !")
 
 
 @util.timeit("debug")
 def get_waveforms(st, event, waveform_type, units):
     """
-    Get real waveforms for a Stream.
+    Get real or simulated waveforms for a Stream.
 
     Parameters
     ----------
     st : `obspy.Stream` object
-        Stream for which to remove response to get real waveforms.
-    event : :class:`~quakemigrate.io.Event` object
-        Light class encapsulating signal, onset, and location information for a
+        Stream for which to get real or simulated waveforms.
+    event : :class:`~quakemigrate.io.event.Event` object
+        Light class encapsulating waveform data and location information for a
         given event.
     waveform_type : {"real", "wa"}
         Whether to get real or Wood-Anderson simulated waveforms.
     units : {"displacement", "velocity"}
-        Units to return real waveforms in.
+        Units to return waveforms in.
 
     Returns
     -------
     st_out : `obspy.Stream` object
-        Stream real or Wood-Anderson simulated waveforms in the requested
+        Stream of real or Wood-Anderson simulated waveforms in the requested
         units.
 
     """
@@ -133,19 +148,20 @@ def get_waveforms(st, event, waveform_type, units):
     st = st.copy()
     st_out = Stream()
 
-    velocity = False
-    if units == "velocity":
-        velocity = True
+    velocity = True if units == "velocity" else False
 
     for tr in st:
-        try:
-            if waveform_type == "real":
-                tr = event.data.get_real_waveform(tr, velocity)
-            else:
-                tr = event.data.get_wa_waveform(tr, velocity)
-            st_out.append(tr)
-        except util.ResponseRemovalError as e:
-            logging.warning(e)
+        # Check there is data present
+        if bool(tr) and tr.data.max() != tr.data.min():
+            try:
+                if waveform_type == "real":
+                    tr = event.data.get_real_waveform(tr, velocity)
+                else:
+                    tr = event.data.get_wa_waveform(tr, velocity)
+                st_out.append(tr)
+            except (util.ResponseNotFoundError,
+                    util.ResponseRemovalError) as e:
+                logging.warning(e)
 
     return st_out
 
@@ -153,7 +169,7 @@ def get_waveforms(st, event, waveform_type, units):
 @util.timeit("debug")
 def write_waveforms(st, fpath, fstem, file_format):
     """
-    Output waveform data as a waveform file -- defaults to mSEED.
+    Output waveform data as a waveform file -- defaults to miniSEED format.
 
     Parameters
     ----------

--- a/quakemigrate/signal/local_mag/amplitude.py
+++ b/quakemigrate/signal/local_mag/amplitude.py
@@ -325,11 +325,14 @@ class Amplitude:
                 else:
                     filter_sos = None
 
-                windows, picked = self._get_amplitude_windows(station, i,
-                                                              event, p_ttimes,
-                                                              s_ttimes,
-                                                              lut.fraction_tt)
-                amps[14] = picked
+                try:
+                    windows, picked = self._get_amplitude_windows(station, i,
+                        event, p_ttimes, s_ttimes, lut.fraction_tt)
+                    amps[14] = picked
+                except util.PickOrderException as e:
+                    logging.warning(f"{e}")
+                    amplitudes.loc[i*3+j] = amps
+                    continue
 
                 amps = self._measure_signal_amps(amps, tr, windows,
                                                  self.noise_measure,

--- a/quakemigrate/signal/local_mag/amplitude.py
+++ b/quakemigrate/signal/local_mag/amplitude.py
@@ -770,8 +770,14 @@ class Amplitude:
                 _, filter_gain = sosfreqz(filter_sos, worN=[approx_freq],
                                           fs=tr.stats.sampling_rate)
                 filter_gain = np.abs(filter_gain[0])
-                half_amp /= filter_gain
-                average_amp /= filter_gain
+                if not filter_gain:
+                    logging.info("\t    Warning: Invalid frequency ("
+                                 f"{approx_freq:.5g} Hz) for {phase}_amp "
+                                 f"measurement on:\n\t\t{tr}")
+                    continue
+                else:
+                    half_amp /= filter_gain
+                    average_amp /= filter_gain
 
             # Put in relevant columns for P / S amplitude, approx_freq,
             # p2t_time

--- a/quakemigrate/signal/local_mag/amplitude.py
+++ b/quakemigrate/signal/local_mag/amplitude.py
@@ -326,8 +326,8 @@ class Amplitude:
                     filter_sos = None
 
                 try:
-                    windows, picked = self._get_amplitude_windows(station, i,
-                        event, p_ttimes, s_ttimes, lut.fraction_tt)
+                    windows, picked = self._get_amplitude_windows(
+                        station, i, event, p_ttimes, s_ttimes, lut.fraction_tt)
                     amps[14] = picked
                 except util.PickOrderException as e:
                     logging.warning(f"{e}")


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
To fix two bugs, and alter the handling of PickOrderException's during amplitude measurement:
1. Handle amplitude measurements outside the frequency range where the filter gain is defined (possible due to the very approximate estimate of the frequency of the peak-to-peak amplitude measurement)
2. Correct the handling of ResponseNotFoundError's during output of real or Wood-Anderson simulated cut waveforms / add handling for the AttributeError raised if a response inventory hasn't been provided.
3. Emit a warning if a PickOrderException occurs during amplitude measurement, instead of raising.

### Relevant Issues
N/A

## Test cases
(1) Tested on data which had initially exposed these issues (Askja 2007-2020 dataset), and (2) tested on the dike example with mags switched on/off and response inventory (not) provided.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 18.04 // python 3.8

### Final checklist
- [x] `master` base branch selected?
- [x] All tests still pass.