### PR TITLE
FIX: Restore plotting of discarded events in Trigger

### DIFF
--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -92,6 +92,8 @@ def trigger_summary(events, starttime, endtime, run, marginal_window,
     fig = plt.figure(figsize=(30, 15))
     gs = (9, 18)
 
+    logging.debug(discarded_events)
+
     # Create plot axes, ordering: [COA, COA_N, AVAIL, XY, XZ, YZ]
     for row in [0, 3, 6]:
         ax = plt.subplot2grid(gs, (row, 8), colspan=10, rowspan=3, fig=fig)

--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -283,9 +283,12 @@ class Trigger:
             discarded = candidate_events
         else:
             refined_events = self._refine_candidates(candidate_events)
+            logging.debug(refined_events)
             events = self._filter_events(refined_events, batchstart, batchend,
                                          region)
-            discarded = refined_events[~refined_events.isin(events)].dropna()
+            logging.debug(events)
+            discarded = refined_events[~refined_events.index.isin(events.index)].dropna()
+            logging.debug(discarded)
             logging.info(f"\n\t\t{len(events)} event(s) triggered within the "
                          f"specified region between {batchstart} \n\t\tand "
                          f"{batchend}")


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
To restore plotting of discarded events (filtered out by the optional `region` trigger kwarg).

### Relevant Issues
#153 

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.
- Operating System: macOS 11.4 Big Sur (x86_64)
- Python version: 3.9.16
- QuakeMigrate version: 1.0.1

### Final checklist
- [x] `master` base branch selected?
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered by new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
