### PR TITLE
Address issue with shared axes from Matplotlib 3.8

### DIFF
--- a/quakemigrate/lut/lut.py
+++ b/quakemigrate/lut/lut.py
@@ -674,8 +674,8 @@ class LUT(Grid3D):
         xz = plt.subplot2grid(gs, (7, 0), colspan=5, rowspan=2, fig=fig)
         yz = plt.subplot2grid(gs, (2, 5), colspan=2, rowspan=5, fig=fig)
 
-        xz.get_shared_x_axes().join(xy, xz)
-        yz.get_shared_y_axes().join(xy, yz)
+        xz.sharex(xy)
+        yz.sharey(xy)
 
         # --- Set aspect ratio ---
         # Aspect is defined such that a circle will be stretched so that its

--- a/quakemigrate/plot/phase_picks.py
+++ b/quakemigrate/plot/phase_picks.py
@@ -62,7 +62,7 @@ def pick_summary(event, station, waveforms, picks, onsets, ttimes, windows):
     axes = fig.axes
 
     # Share P-pick x-axes and set title
-    axes[0].get_shared_x_axes().join(axes[0], axes[3])
+    axes[0].sharex(axes[3])
     axes[0].set_xticklabels([])
     axes[0].set_yticklabels([])
     axes[0].yaxis.set_ticks_position("none")
@@ -71,7 +71,7 @@ def pick_summary(event, station, waveforms, picks, onsets, ttimes, windows):
 
     # Share S-pick x-axes and set title
     for ax in axes[1:3]:
-        ax.get_shared_x_axes().join(ax, axes[4])
+        ax.sharex(axes[4])
         ax.set_xticklabels([])
         ax.set_yticklabels([])
         ax.yaxis.set_ticks_position("none")

--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -110,7 +110,7 @@ def trigger_summary(
 
     # --- Plot LUT, coalescence traces, and station availability ---
     for ax in fig.axes[:2]:
-        ax.get_shared_x_axes().join(ax, fig.axes[2])
+        ax.sharex(fig.axes[2])
     _plot_coalescence(fig.axes[0], dt, data.COA.values, "Maximum coalescence")
     _plot_coalescence(
         fig.axes[1], dt, data.COA_N.values, "Normalised maximum coalescence"


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Address an issue arising with the release of Matplotlib 3.8, wherein the syntax for defining shared axes was changed.

Every instance of `get_shared_x_axes`/`get_shared_y_axes` has been remapped to `ax.sharex` or `ax.sharey`.

This addresses the closed Pull Request #161.

### Relevant Issues
No open issue, but previously acknowledged and discussed in Pull Request #161.

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Tested on macOS Monterey v12.5.1. Python 3.11.5, matplotlib 3.8.0.

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered by new tests.
- [x] Any new or changed features are fully documented.
