### PR TITLE
:wrench: Update cibuildwheels version to fix Windows wheel building

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.5
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Bump of cibuildwheel version to fix #170  -- cibuildwheel 2.12.0 -> 2.16.5

As per https://github.com/pypa/cibuildwheel/issues/1740

### Relevant Issues
#170 

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
(Tested on ubuntu 22.04; but really needs to run actions workflow to test)

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.