### PR TITLE
:bug: Single client request for all stations

### DIFF
--- a/examples/Volcanotectonic_Iceland/get_dike_intrusion_data.py
+++ b/examples/Volcanotectonic_Iceland/get_dike_intrusion_data.py
@@ -29,17 +29,16 @@ endtime = UTCDateTime("2014-236T00:15:00")
 
 #  --- Read in station file ---
 stations = read_stations(station_file)
+stations_string = ",".join(stations["Name"])
 
 # --- Download instrument response inventory ---
-inv = Inventory()
-for station in stations["Name"]:
-    inv += client.get_stations(
-        network=network,
-        station=station,
-        starttime=starttime,
-        endtime=endtime,
-        level="response",
-    )
+inv = client.get_stations(
+    network=network,
+    station=stations_string,
+    starttime=starttime,
+    endtime=endtime,
+    level="response",
+)
 inv.write(response_file, format="STATIONXML")
 
 # --- Make directories to store waveform data ---
@@ -47,20 +46,23 @@ waveform_path = data_path / str(starttime.year) / f"{starttime.julday:03d}"
 waveform_path.mkdir(parents=True, exist_ok=True)
 
 # --- Download waveform data ---
+print(f"Downloading waveform data from {datacentre}")
+st = client.get_waveforms(
+    network=network,
+    station=stations_string,
+    location="*",
+    channel="*H*",
+    starttime=starttime,
+    endtime=endtime,
+)
+st.merge(method=-1)
+
+# --- Write waveform data to disk ---
 for station in stations["Name"]:
-    print(f"Downloading waveform data for station {station} from {datacentre}")
-    st = client.get_waveforms(
-        network=network,
-        station=station,
-        location="*",
-        channel="*H*",
-        starttime=starttime,
-        endtime=endtime,
-    )
-    st.merge(method=-1)
+    print(f"Writing data from station {station} to disk")
     for comp in ["E", "N", "Z"]:
         try:
-            st_comp = st.select(component=comp)
+            st_comp = st.select(station=station, component=comp)
             st_comp.write(str(waveform_path / f"{station}_{comp}.m"), format="MSEED")
         except IndexError:
             pass


### PR DESCRIPTION
Previously data was downloaded from each station sequentially in a loop; this instead makes use of the ability to list multiple stations in a single request. This should speed things up a little, and hopefully address #172


<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Initiated by failure of the automatic test run, seemingly due to timing out during data download for the VT-Iceland example. Hopefully by reducing requests we stay beneath any traffic limits, but this also provides a significant speed-up in the data download.

### Relevant Issues
#172 - [Tests timing out on data acquisition from EarthScope stage](https://github.com/QuakeMigrate/QuakeMigrate/issues/172)

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 22.04

### Final checklist
- [x] Correct base branch selected?
- [x] All tests still pass.
