### PR TITLE
FIX: Replace deprecated (renamed) function within `numpy` (#187).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
 
+1.1.2
+=====
+Address a bug in Trigger caused by a deprecated (renamed) function within `numpy` (#187).
+
+- quakemigrate.signal.trigger
+  * Replace `np.product()` (deprecated in numpy v2.0.0) with the new syntax `np.prod()`.
+
 1.1.1
 =====
 Address a bug in amplitude plotting introduced in v1.1.0, and modify the Volcanotectonic_Iceland example such that this issue is now covered by tests going forwards.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,19 @@
 
 1.1.2
 =====
-Address a bug in Trigger caused by a deprecated (renamed) function within `numpy` (#187).
+Address a bug in Trigger caused by a deprecated numpy function, minor bugfixes within the local magnitudes sub-module, and fix coverage reporting with CodeCov.
 
+- quakemigrate.io.amplitudes
+  * Handle the case where no amplitude measurements are made for an event. acc6bd9
+- quakemigrate.signal.local_mag.local_mag
+  * Fix handling of no amplitude measurements when adding a local magnitude to an event. 1f60f64
+- quakemigrate.signal.local_mag.magnitude
+  * Fix application of `filter_gain` to noise amplitude measurements, within magnitude calculation and amplitudes plotting.
+  * Fix handling of `ML_Err` and `ML_r2` calculation where only a single magnitude estimate is available for event. 03a3032
 - quakemigrate.signal.trigger
-  * Replace `np.product()` (deprecated in numpy v2.0.0) with the new syntax `np.prod()`.
+  * Replace `np.product()` (deprecated in numpy v2.0.0) with the new syntax `np.prod()`. bee2b34
+- tests:
+  * Update the process for analysing package coverage of the tests, including fixing path issue that was breaking CodeCov report parsing via adding `codecov.yml`, and updating versions of all component actions. 6dd40ba
 
 1.1.1
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = ["quakemigrate*"]
 
 [project]
 name = "quakemigrate"
-version = "1.1.1"
+version = "1.1.2"
 description = "A Python package for automatic earthquake detection and location using waveform migration and stacking."
 readme = "README.md"
 license = {text = "GPLv3"}

--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -3,7 +3,7 @@
 Module to perform the trigger stage of QuakeMigrate.
 
 :copyright:
-    2020–2023, QuakeMigrate developers.
+    2020–2024, QuakeMigrate developers.
 :license:
     GNU General Public License, Version 3
     (https://www.gnu.org/licenses/gpl-3.0.html)
@@ -40,7 +40,7 @@ def chunks2trace(a, new_shape):
     """
 
     b = np.broadcast_to(a[:, None], new_shape)
-    b = np.reshape(b, np.product(new_shape))
+    b = np.reshape(b, np.prod(new_shape))
 
     return b
 


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Address a bug in Trigger caused by a deprecated (renamed) function within `numpy` (#187).

### Relevant Issues
#187 

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Ubuntu 22.04 / Python 3.12.5 / AMD Epyc

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.
- [-] Any new features or fixed regressions are covered by new tests.
- [-] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
