### PR TITLE
BUGFIX: trigger plot failure when no events

### DIFF
--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -148,12 +148,12 @@ def trigger_summary(
         _plot_event_scatter(fig, discarded_events, discarded=True)
 
     # --- Plot event scatter on LUT and windows on coalescence traces ---
-    if events is not None:
+    ax_i = 1 if normalise_coalescence else 0
+    if not events.empty:
         _plot_event_windows(fig.axes[:2], events, marginal_window)
         _plot_event_scatter(fig, events)
 
         # Add trigger threshold to the correct coalescence trace
-        ax_i = 1 if normalise_coalescence else 0
         fig.axes[ax_i].step(
             dt, detection_threshold, where="mid", c="g", label="Detection threshold"
         )

--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -148,15 +148,15 @@ def trigger_summary(
         _plot_event_scatter(fig, discarded_events, discarded=True)
 
     # --- Plot event scatter on LUT and windows on coalescence traces ---
-    ax_i = 1 if normalise_coalescence else 0
     if not events.empty:
         _plot_event_windows(fig.axes[:2], events, marginal_window)
         _plot_event_scatter(fig, events)
 
-        # Add trigger threshold to the correct coalescence trace
-        fig.axes[ax_i].step(
-            dt, detection_threshold, where="mid", c="g", label="Detection threshold"
-        )
+    # --- Add trigger threshold to the correct coalescence trace ---
+    ax_i = 1 if normalise_coalescence else 0
+    fig.axes[ax_i].step(
+        dt, detection_threshold, where="mid", c="g", label="Detection threshold"
+    )
 
     # --- Write summary information ---
     text = plt.subplot2grid(gs, (0, 0), colspan=8, rowspan=2, fig=fig)
@@ -473,7 +473,7 @@ def _plot_text_summary(
 
     # Get trigger on and event count info
     trig = "normalised coalescence" if normalise_coalescence else "coalescence"
-    count = len(events) if events is not None else 0
+    count = len(events)
 
     with plt.rc_context({"font.size": 18}):
         ax.text(0.45, 0.65, "Trigger threshold:", ha="right", va="center")


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Fix an issue with the trigger plotting function when no events were available to be plotted. Now, instead of `None`, an empty Pandas DataFrame is passed in to the plotting function, but the if statement still expected None when no events to be plotted.

### Relevant Issues
None

## Test cases
Ran the trigger stage for a day of data for which the trigger plotting issue had arisen (no events triggered). Ran successfully.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.
