### PR TITLE
BUG: Correctly set default trigger method when instantiating a new Trigger object

### DIFF
--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -205,17 +205,13 @@ class Trigger:
         self.run.logger(kwargs.get("log", False))
 
         # --- Grab Trigger parameters or set defaults ---
-        self.threshold_method = kwargs.get("threshold_method")
-        if self.threshold_method == "static":
-            self.static_threshold = kwargs.get("static_threshold", 1.5)
-        elif self.threshold_method == "mad":
-            self.mad_window_length = kwargs.get("mad_window_length", 3600.0)
-            self.mad_multiplier = kwargs.get("mad_multiplier", 8.0)
-        elif self.threshold_method == "median_ratio":
-            self.median_window_length = kwargs.get("median_window_length", 3600.0)
-            self.median_multiplier = kwargs.get("median_multiplier", 1.2)
-        else:
-            raise util.InvalidTriggerThresholdMethodException
+        self.threshold_method = kwargs.get("threshold_method", "static")
+        self.static_threshold = kwargs.get("static_threshold", 1.5)
+        self.mad_window_length = kwargs.get("mad_window_length", 3600.0)
+        self.mad_multiplier = kwargs.get("mad_multiplier", 8.0)
+        self.median_window_length = kwargs.get("median_window_length", 3600.0)
+        self.median_multiplier = kwargs.get("median_multiplier", 1.2)
+
         self.marginal_window = kwargs.get("marginal_window", 2.0)
         self.min_event_interval = kwargs.get("min_event_interval", 4.0)
         if kwargs.get("minimum_repeat"):
@@ -692,6 +688,26 @@ class Trigger:
         else:
             self._min_event_interval = value
 
+    @property
+    def threshold_method(self):
+        """Get and set the threshold method."""
+
+        return self._threshold_method
+
+    @threshold_method.setter
+    def threshold_method(self, value):
+        if value in ["static", "mad", "median_ratio"]:
+            self._threshold_method = value
+        elif value == "dynamic":
+            # DEPRECATED
+            print(
+                "FutureWarning: This threshold method has been renamed - continuing.\n"
+                "To remove this message, change:\n\t'dynamic' -> 'mad'"
+            )
+            self._threshold_method = "mad"
+        else:
+            raise util.InvalidTriggerThresholdMethodException
+
     # --- Deprecation/Future handling ---
     @property
     def minimum_repeat(self):
@@ -709,23 +725,3 @@ class Trigger:
             "\t'minimum_repeat' -> 'min_event_interval'"
         )
         self._min_event_interval = value
-
-    # --- Deprecation/Future handling ---
-    @property
-    def threshold_method(self):
-        """Handle deprecated 'dynamic' threshold method."""
-        return self._threshold_method
-
-    @threshold_method.setter
-    def threshold_method(self, value):
-        """Handle deprecated threshold_method kwarg / attribute and print warning."""
-
-        if value == "dynamic":
-            # DEPRECATED
-            print(
-                "FutureWarning: This threshold method has been renamed - continuing.\n"
-                "To remove this message, change:\n\t'dynamic' -> 'mad'"
-            )
-            self._threshold_method = "mad"
-        else:
-            self._threshold_method = value

--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -205,7 +205,7 @@ class Trigger:
         self.run.logger(kwargs.get("log", False))
 
         # --- Grab Trigger parameters or set defaults ---
-        self.threshold_method = kwargs.get("threshold_method", "static")
+        self.threshold_method = kwargs.get("threshold_method")
         if self.threshold_method == "static":
             self.static_threshold = kwargs.get("static_threshold", 1.5)
         elif self.threshold_method == "mad":

--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -1070,7 +1070,9 @@ class InvalidTriggerThresholdMethodException(Exception):
     """
 
     def __init__(self):
-        super().__init__("Only 'static' or 'dynamic' thresholds are supported.")
+        super().__init__(
+            "Only 'static', 'mad' or 'median_ratio' thresholds are " "supported."
+        )
 
 
 class InvalidPickThresholdMethodException(Exception):


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Update the default trigger threshold when instantiating a new Trigger object to be `None` if no keyword argument is supplied, NOT `static`. This now means a `InvalidTriggerThresholdMethodException` should correctly be raised.

### Relevant Issues
N/A

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
macOS 12.5.1, M1 chip

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered by new tests.
- [x] Any new or changed features are fully documented.
