### PR TITLE
Fix small bug with empty ScanMSEED objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-
+1.2.0
+=====
 - Examples:
   * Switched to using the obspy `MassDownloader` to download data for all examples; thus removing the bundled data for the two icequake examples from the repo, and speeding up data download for the VT_Iceland example. 7788af7, 7e1e3d0, 6694459
   * Corresponding fixes and updates to icequake example notebooks 56a1f88, 2f95095

--- a/quakemigrate/io/scanmseed.py
+++ b/quakemigrate/io/scanmseed.py
@@ -174,7 +174,7 @@ class ScanmSEED:
         logging.info(msg)
 
         starttime = starttime + timestep * i
-        n = util.time2sample(timestep, self.sampling_rate) + 1
+        n = util.time2sample(timestep, self.sampling_rate)
         max_coa = max_coa_n = np.full(n, 0)
         coord = np.full((n, 3), 0)
 

--- a/quakemigrate/signal/scan.py
+++ b/quakemigrate/signal/scan.py
@@ -451,17 +451,11 @@ class QuakeScan:
                     time, max_coa, max_coa_n, coord, self.lut.unit_conversion_factor
                 )
                 availability.loc[i] = onset_data.availability
-            except util.ArchiveEmptyException as e:
-                coalescence.empty(
-                    starttime, self.timestep, i, e.msg, self.lut.unit_conversion_factor
-                )
-                availability.loc[i] = np.zeros(len(availability_cols), dtype=int)
-            except util.DataGapException as e:
-                coalescence.empty(
-                    starttime, self.timestep, i, e.msg, self.lut.unit_conversion_factor
-                )
-                availability.loc[i] = np.zeros(len(availability_cols), dtype=int)
-            except util.DataAvailabilityException as e:
+            except (
+                util.ArchiveEmptyException,
+                util.DataGapException,
+                util.DataAvailabilityException,
+            ) as e:
                 coalescence.empty(
                     starttime, self.timestep, i, e.msg, self.lut.unit_conversion_factor
                 )
@@ -514,13 +508,11 @@ class QuakeScan:
                 event.add_compute_output(  # pylint: disable=E1120
                     *self._compute(event.data, event)
                 )
-            except util.ArchiveEmptyException as e:
-                logging.info(e.msg)
-                continue
-            except util.DataGapException as e:
-                logging.info(e.msg)
-                continue
-            except util.DataAvailabilityException as e:
+            except (
+                util.ArchiveEmptyException,
+                util.DataGapException,
+                util.DataAvailabilityException,
+            ) as e:
                 logging.info(e.msg)
                 continue
 


### PR DESCRIPTION
## What is the purpose of this Pull Request? 
In instances when no data pass the criteria for a given timestep (or don't exist in the archive), an empty portion of data is added to the `ScanMSEED` object, equal in length to the timestep. There was a small bug, a hangover from other changes to how the timestep is handled bundled as part of v1.2.0, that meant an additional sample was added to this empty section. Previously this sample had been removed when this block was appended to the running `ScanMSEED` object. Since this was no longer removed, this bug led to multiple traces with a 1 sample overlap in the `ScanMSEED` object that could not be simply merged. This PR fixes this.

## Test cases
Ran this with a period of time where all data did not pass the selection criteria for the first timestep of the day (i.e., there was no waveform data for the previous day in the period just before midnight, which is required by the pre-pad for the onset function calculation). This was where the bug was identified. The change introduced in this PR resolved this.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
macOS 12.5.1 M1 chip

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.
