### PR TITLE
:bug: update PyPI publish action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,7 +86,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.9.0
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.9.0
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Update PyPI publish action from v1.9.0 to v1.12.4, which should handle issues with package metadata that was causing the publish workflow to fail.

### Relevant Issues
None

## Test cases
No changes to codebase, so tests still pass.

### System details
Not tested, as this is run as a GitHub Action.

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [x] All tests still pass.