### PR TITLE
bugfix: updated get_phase_component_strings() to plot when no S picks

### DIFF
--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -683,6 +683,9 @@ def get_phase_component_strings(channel_maps):
     that flexible) plotting setup. If the use of this function is expanded beyond that
     of a plotting utility, this might need to be revised.
 
+    Ammended to facilitate plotting when no S picks are made, e.g. in case of having
+    vertical components only, through if statement.
+
     Currently all P-phase components are retained; this means if more than one
     component is specified for the P onset, the waveforms will be overlain.
 
@@ -706,46 +709,55 @@ def get_phase_component_strings(channel_maps):
     """
 
     p_comps = list(channel_maps["P"].strip("*").strip("[").strip("]"))[::2]
-    s_comps = list(channel_maps["S"].strip("*").strip("[").strip("]"))[::2]
-    p_str, s_str_1, s_str_2 = "", "", ""
+    p_str = ""
+
     for p_comp in p_comps:
         p_str += f"{p_comp},"
-    s_comps_alpha = [
-        s_comps[i] for i in np.where([not x.isnumeric() for x in s_comps])[0]
-    ]
-    s_comps_numeric = [
-        s_comps[i] for i in np.where([x.isnumeric() for x in s_comps])[0]
-    ]
-    if s_comps_alpha and s_comps_numeric:
-        if len(s_comps_alpha) > 2 or len(s_comps_numeric) > 2:
-            logging.info(
-                "More than two pairs of S-phase components found in "
-                "channel maps. Only using first two for plotting!"
-            )
-        for i, (s_alpha, s_numeric) in enumerate(zip(s_comps_alpha, s_comps_numeric)):
-            if i == 0:
-                s_str_1 += f"{s_alpha},{s_numeric},"
-            elif i == 1:
-                s_str_2 += f"{s_alpha},{s_numeric},"
-            elif i > 1:
-                continue
-    else:
-        for s_comps_list in [s_comps_alpha, s_comps_numeric]:
-            if s_comps_list:
-                s_str_1 += f"{s_comps_list[0]},"
-                if len(s_comps_list) > 1:
-                    s_str_2 += f"{s_comps_list[1]},"
-            if len(s_comps_list) > 2:
-                logging.info(
-                    "More than two alphabetical or numeric S-phase components"
-                    " found in channel maps. Only using first two for plotting!"
-                )
 
     p_str = f"[{p_str.rstrip(',')}]"
-    s_str_1 = f"[{s_str_1.rstrip(',')}]"
-    s_str_2 = f"[{s_str_2.rstrip(',')}]"
 
-    return p_str, s_str_1, s_str_2
+    if "S" in channel_maps:
+        s_str_1, s_str_2 = "", ""
+        s_comps = list(channel_maps["S"].strip("*").strip("[").strip("]"))[::2]
+        s_comps_alpha = [
+            s_comps[i] for i in np.where([not x.isnumeric() for x in s_comps])[0]
+        ]
+        s_comps_numeric = [
+            s_comps[i] for i in np.where([x.isnumeric() for x in s_comps])[0]
+        ]
+        if s_comps_alpha and s_comps_numeric:
+            if len(s_comps_alpha) > 2 or len(s_comps_numeric) > 2:
+                logging.info(
+                    "More than two pairs of S-phase components found in "
+                    "channel maps. Only using first two for plotting!"
+                )
+            for i, (s_alpha, s_numeric) in enumerate(
+                zip(s_comps_alpha, s_comps_numeric)
+            ):
+                if i == 0:
+                    s_str_1 += f"{s_alpha},{s_numeric},"
+                elif i == 1:
+                    s_str_2 += f"{s_alpha},{s_numeric},"
+                elif i > 1:
+                    continue
+        else:
+            for s_comps_list in [s_comps_alpha, s_comps_numeric]:
+                if s_comps_list:
+                    s_str_1 += f"{s_comps_list[0]},"
+                    if len(s_comps_list) > 1:
+                        s_str_2 += f"{s_comps_list[1]},"
+                if len(s_comps_list) > 2:
+                    logging.info(
+                        "More than two alphabetical or numeric S-phase components"
+                        " found in channel maps. Only using first two for plotting!"
+                    )
+
+        s_str_1 = f"[{s_str_1.rstrip(',')}]"
+        s_str_2 = f"[{s_str_2.rstrip(',')}]"
+
+        return p_str, s_str_1, s_str_2
+    else:
+        return p_str
 
 
 class StationFileHeaderException(Exception):


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
I am trying to use QuakeMigrate to identify ice quakes but my array consists only of vertical component nodes. Every other aspect of the code works when setting the phase to only P, except for the function get_phase_component_strings(), causing the code to error when running the relative relocation plotting.  Have modified to include an if statement, so only gets and returns the S strings if S is a valid channel. 

### Relevant Issues
Link any open Issues here.

## Test cases

- Rutford ice stream example runs as written even with new changes, but if you set the phase list to only be P in all instances, no longer errors at scan and can run through the whole example.

### System details
Ubuntu 20.04.6 LTS

### Final checklist
- [ ] Correct base branch selected?
    - `master` (if a bugfix/patch update)
    - `version/vX.X.X` if a new significant feature (discuss with developers)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered by new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.  --> didn't feel this was really necessary for an if statement
