### PR TITLE
:wrench: Remove use of `pkg_resources`

### DIFF
--- a/quakemigrate/__init__.py
+++ b/quakemigrate/__init__.py
@@ -11,7 +11,7 @@ using waveform migration and stacking.
 
 """
 
-import pkg_resources
+from importlib.metadata import version
 
 import matplotlib
 import os
@@ -27,4 +27,4 @@ logging.getLogger("matplotlib").setLevel(logging.INFO)
 if "DISPLAY" not in os.environ:
     matplotlib.use("Agg")
 
-__version__ = pkg_resources.get_distribution("quakemigrate").version
+__version__ = version("quakemigrate")


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Use of `pkg_resources` now triggers a `UserWarning` from `setuptools` - this PR switches to instead using `importlib.metadata.version` to populate the `__version__` attribute.

### Relevant Issues
N/A

## Test cases
With the currently available version of `setuptools` importing any part of the `quakemigrate` package would result in this `UserWarning`. With this change the warning is no longer shown (and `quakemigrate.__version__` still returns the expected `1.2.0`).

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass
   - Note: I am currently receiving a LUT-related test failure, but this was seen both before and after this change, and is not relevant.

### System details
Please state the systems on which you have tested this change.
Apple M4 Pro / macOS 15.5 / Python 3.12.11

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.