### PR TITLE
:test_tube: Add `get_data` to `run_test_examples.py`

### DIFF
--- a/tests/run_test_examples.py
+++ b/tests/run_test_examples.py
@@ -18,6 +18,7 @@ base_path = pathlib.Path(__file__).resolve().parent.parent / "examples"
 
 # Run Iceland icequake example scripts
 os.chdir(base_path / "Icequake_Iceland")
+exec(open("get_iceland_icequake_data.py").read())
 exec(open("iceland_lut.py").read())
 exec(open("iceland_detect.py").read())
 exec(open("iceland_trigger.py").read())


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
When the `Icequake_Iceland` example data was removed from the repo and replaced with the get_data script (in 6694459), it was not added to the `run_test_examples.py` script, leading to an inconvenient failure if trying to run this immediately after a fresh clone. (The VT_Iceland get_data script was already there). This PR resolves this.

### Relevant Issues
N/A

## Test cases
`run_test_examples.py` now runs cleanly from a fresh clone.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Apple M4 Pro / macOS 15.5 / Python 3.12.11

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.