### PR TITLE
:bug: Remove use of removed `pandas.DataFrame.iteritems()`

### DIFF
--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -129,7 +129,7 @@ def trigger_summary(
     if availability is not None:
         station_list = []
         if not plot_all_stns:
-            for col, ava in availability.iteritems():
+            for col, ava in availability.items():
                 if np.any(ava == 1):
                     station_list.append(col.split("_")[0])
         else:


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
As described in #204, `DataFrame.iteritems()` was removed in pandas 2.0, resulting in a failure within trigger plotting. This commit implements the discussed (and recommended) alternative `DataFrame.items()`. Also verified that there were no further instances of this function being used within the package.

### Relevant Issues
#204 

## Test cases
Tested the `Icequake_Iceland` example with `trig.plot_all_stns = False` (as described by @hemmelig in #204) to verify that this change resolved the failure - and resulted in a trigger summary plot with station "SKG09" excluded.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass
    - Note: I am currently receiving a LUT-related test failure, but this was seen both before and after this change, and is not relevant.

### System details
Apple M4 Pro / macOS 15.5 / Python 3.12.11

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.
