### PR TITLE
:bug: Add checkout as workaround to codecov issue

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -105,6 +105,7 @@ jobs:
     needs: [run_tests]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: coverage_artifact


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Codecov reports not showing since April (similar to other users reported in https://github.com/codecov/codecov-action/issues/1801). Trying the specified workaround of adding a (should be..) unnecessary checkout before downloading the artifact.

### Relevant Issues
N/A

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [ ] Coverage report works within PR

### System details
N/A

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [ ] All tests still pass.
