### PR TITLE
:bug: Use rounded int for `full_timespan` test

### DIFF
--- a/quakemigrate/io/data.py
+++ b/quakemigrate/io/data.py
@@ -604,7 +604,7 @@ class WaveformData:
                 # rate as provided. To check that as well, use
                 # `check_sampling_rate=True` and specify a sampling rate.
                 if full_timespan:
-                    n_samples = timespan * st_id[0].stats.sampling_rate + 1
+                    n_samples = int(round(timespan * st_id[0].stats.sampling_rate + 1))
                     if len(st_id) > 1:
                         continue
                     elif st_id[0].stats.npts < n_samples:


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Use a rounded integer when calculating `n_samples` for the `full_timespan` test in `io.data.WaveformData.check_availability()`, to avoid floating point errors.

See #216 for more information about the bug in question.

### Relevant Issues
#216 

## Test cases
This fix resolves the issue reported in #216 with the dataset that initially revealed this bug.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
- Operating System: macOS 15.6.1
- Python version: 3.12.11
- QuakeMigrate version: 1.2.1

Note due to #210 test_benchmarks does not run successfully on my system (same minor discrepancy somewhere in LUT generation), but the automated tests run fine, and the error is the same as before this change was made.

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.
- [ ] Significant changes have been added to `CHANGES.md`.
