### PR TITLE
:wrench: Add `nllgrid` dependency for the manuscript

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 dev = ["ipython", "pre-commit", "ruff", "coverage"]
 docs = ["docutils<0.17", "Sphinx >= 4.3.0", "sphinx_rtd_theme>=0.5.1"]
 fmm = ["scikit-fmm"]
-manuscript = ["memray", "seaborn"]
+manuscript = ["memray", "seaborn", "nllgrid"]
 
 [project.urls]
 GitHub = "https://github.com/QuakeMigrate/QuakeMigrate"


### PR DESCRIPTION
Add `nllgrid` to the list of dependencies for the "manuscript" optional dependencies list.


<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Add the package `nllgrid` to the list of dependencies in the "manuscript" optional dependencies list - corresponding to the change made there to calculate incidence angles from the NLLoc angles grid: https://github.com/QuakeMigrate/manuscript/commit/b47f4b7d9d431fe323492fdcb91bd10d68b5ecb3

### Relevant Issues
N/A

## Test cases
Fresh install in new conda environment worked without issues. Then able to run the relevant (synthetic) scripts from the manuscript repo successfully, and producing the expected outputs.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
- Ubuntu 22.04
- Python 3.12
- quakemigrate v1.2.1

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.
