### PR TITLE
FIX: macOS build wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v3.3.0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,7 +23,7 @@ jobs:
       CIBW_ARCHS: 'native'
       CIBW_SKIP: '*i686 *s390x *ppc64le *musllinux*'
       CIBW_ENVIRONMENT: >-
-       MACOSX_DEPLOYMENT_TARGET=14.0
+       MACOSX_DEPLOYMENT_TARGET=15.0
        LDFLAGS=-L/opt/homebrew/opt/libomp/lib
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Update the configuration of the `build_wheels` workflow to fix #218

### Relevant Issues
#218 

## Test cases
Build was tested (in mutliple configurations) by pushing to a temporary branch `test_wheels_fix_macos_build_wheels` where the issue was diagnosed to be caused by the `MACOSX_DEPLOYMENT_TARGET` environment variable for `cibuildwheels`. As expected, updating this from `14.0` to `15.0` resolved the issue.

### System details
(Tested on GH Actions runners)

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.

Fixes #218 