### PR TITLE
FIX: Handle NaN magnitudes in `export.to_obspy`

### DIFF
--- a/quakemigrate/export/to_obspy.py
+++ b/quakemigrate/export/to_obspy.py
@@ -4,7 +4,7 @@ This module provides parsers to export the output of a QuakeMigrate run to an Ob
 Catalog.
 
 :copyright:
-    2020–2023, QuakeMigrate developers.
+    2020–2025, QuakeMigrate developers.
 :license:
     GNU General Public License, Version 3
     (https://www.gnu.org/licenses/gpl-3.0.html)
@@ -306,17 +306,20 @@ def _read_single_event(event_file, locate_dir, units, local_mag_ph):
 
                 event.amplitudes.append(amp)
 
-        mag = Magnitude()
-        mag.extra = AttribDict()
-        mag.mag = event_info["ML"]
-        mag.mag_errors.uncertainty = event_info["ML_Err"]
-        mag.magnitude_type = "ML"
-        # mag.origin_id = ?
-        mag.station_count = i
-        mag.evaluation_mode = "automatic"
-        mag.extra.r2 = {"value": event_info["ML_r2"], "namespace": ns}
+        if pd.isna(event_info["ML"]):
+            print(f"Event {event_uid} has no valid magnitude; not added.")
+        else:
+            mag = Magnitude()
+            mag.extra = AttribDict()
+            mag.mag = event_info["ML"]
+            mag.mag_errors.uncertainty = event_info["ML_Err"]
+            mag.magnitude_type = "ML"
+            # mag.origin_id = ?
+            mag.station_count = i
+            mag.evaluation_mode = "automatic"
+            mag.extra.r2 = {"value": event_info["ML_r2"], "namespace": ns}
 
-        event.magnitudes = [mag]
-        event.preferred_magnitude_id = mag.resource_id
+            event.magnitudes = [mag]
+            event.preferred_magnitude_id = mag.resource_id
 
     return event


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Add a catch for events with NaN magnitude in the parsing function bundled as `export.to_obspy.read_quakemigrate()`. A similar catch was already present for the `StationMagnitude` lines.


### Relevant Issues
#220

## Test cases
A dummy catalogue was created (using events from the `Askja_Iceland_VT-DLP` example), where the magnitude for one event was manually set to NaN. Initially the same bug described in #220 was encountered; with the fix implemented here the event was still imported but without a `Magnitude` object - as intended.

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
- Ubuntu 22.04
- Python 3.12.11

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.

Fixes #220