### PR TITLE
FIX: Remove concurrency restriction for `run_tests` workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,10 +16,6 @@ on:
     types: 
       - published
 
-concurrency:
-  group: wheels-${{ github.event_name }}-${{ github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   run_tests:
     name: Run tests on (ubuntu-latest, Python ${{ matrix.python-version }})


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Previously we have always had to manually restart the workflow for publishing a release, because it has been cancelled by the concurrency criterion imposed in `run_tests.yml`. This concurrency test:
 - was labelling tests jobs as `wheels`
 - isn't necessary (as yet) This commit removes it, and hopefully smooths over the release process.

### Relevant Issues
N/A

## Test cases
Not tested. Proof will be in the next bugfix release.

### System details
N/A

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)