### PR TITLE
FIX: Fix scalar conversion in synthetic example

### DIFF
--- a/examples/synthetic/simulate/core.py
+++ b/examples/synthetic/simulate/core.py
@@ -2,7 +2,7 @@
 Small module that provides basic waveform simulations routines.
 
 :copyright:
-    2020–2024, QuakeMigrate developers.
+    2020–2026, QuakeMigrate developers.
 :license:
     GNU General Public License, Version 3
     (https://www.gnu.org/licenses/gpl-3.0.html)
@@ -84,7 +84,7 @@ def simulate_waveforms(
 
     Parameters
     ----------
-    wavelet: The base wavelet used to represent the waveform for each simulated phase.                                                                 
+    wavelet: The base wavelet used to represent the waveform for each simulated phase.
     earthquake_coords: The lon, lat, and depth of the earthquake.
     lut: A QuakeMigrate traveltime lookup table, used to migrate simulated waveforms.
     magnitude: A local magnitude used to simulate the effect of distance attenuation.
@@ -120,7 +120,7 @@ def simulate_waveforms(
         P = Trace()
         P_ttime = lut.traveltime_to("P", earthquake_ijk, station=station)
         P_ttime += np.random.normal(scale=noise["traveltime"]["P"], size=1)
-        roll_by = int(wavelet.sps * P_ttime)
+        roll_by = int(wavelet.sps * P_ttime[0])
         P_amp_noise = np.random.normal(
             scale=noise["amplitude"]["P"], size=len(wavelet.data)
         )
@@ -130,7 +130,7 @@ def simulate_waveforms(
         S1, S2 = Trace(), Trace()
         S_ttime = lut.traveltime_to("S", earthquake_ijk, station=station)
         S_ttime += np.random.normal(scale=noise["traveltime"]["S"], size=1)
-        roll_by = int(wavelet.sps * S_ttime)
+        roll_by = int(wavelet.sps * S_ttime[0])
         S_amp_noise = np.random.normal(
             scale=noise["amplitude"]["S"], size=len(wavelet.data)
         )


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Fixes a bug in the synthetic example introduced by stricter treatment of scalar conversion in numpy > 2.4.0.

### Relevant Issues
#228

## Test cases
Synthetic example now runs without errors

- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
 - Operating System: Debian 6.1.153-1
 - Python version: 3.12.12
 - QuakeMigrate version: 1.2.2
 - numpy version: 2.4.0

### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.

Closes #228 