### PR TITLE
FEAT: Add the option to ignore network & loc codes in waveform archives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+- quakemigrate.io.data
+  * Add the option to ignore network codes and location codes in the waveform data archive. This may be useful when a given station (or set of stations) have been assigned different temporary network codes at different times during the study period; i.e. not reflecting any physical change to the station infrastructure, but which would otherwise prevent waveforms from being merged due to their incompatible SEED ID's. This is also reflected in the output cut waveforms.
+- quakemigrate.io.core
+  * Add the option to ignore network codes and location codes in the instrument response inventory; see corresponding change in quakemigrate.io.data for further details.
+
 1.2.2
 =====
 - GH Actions

--- a/quakemigrate/io/data.py
+++ b/quakemigrate/io/data.py
@@ -409,6 +409,27 @@ class Archive:
 
         return files
 
+    @property
+    def dummy_network_code(self):
+        """
+        Dummy network code is a 2 character string to replace the (possibly mixed) network
+        codes in the input archive.
+
+        """
+
+        return self._dummy_network_code
+
+    @dummy_network_code.setter
+    def dummy_network_code(self, value):
+        """Setter for dummy network code."""
+
+        if isinstance(value, str) and len(value) == 2:
+            self._dummy_network_code = value
+        else:
+            raise ValueError(
+                f"`dummy_network_code` must be a 2 character string, not {value}."
+            )
+
 
 class WaveformData:
     """
@@ -806,24 +827,3 @@ class WaveformData:
             self.wa_waveforms.append(tr.copy())
 
         return tr
-
-    @property
-    def dummy_network_code(self):
-        """
-        Dummy network code is a 2 character string to replace the (possibly mixed) network
-        codes in the input archive.
-
-        """
-
-        return self._dummy_network_code
-
-    @dummy_network_code.setter
-    def dummy_network_code(self, value):
-        """Setter for dummy network code."""
-
-        if isinstance(value, str) and len(value) == 2:
-            self._dummy_network_code = value
-        else:
-            raise ValueError(
-                f"`dummy_network_code` must be a 2 character string, not {value}."
-            )


### PR DESCRIPTION
<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Add the option to ignore network codes and location codes in the waveform data archive. This may be useful when a given station (or set of stations) have been assigned different temporary network codes at different times during the study period; i.e. not reflecting any physical change to the station infrastructure, but which would otherwise prevent waveforms from being merged due to their incompatible SEED ID's. This is also reflected in the output cut waveforms.

This is achieved through the addition of three new attributes to the `Archive` class, and corresponding kwargs to the funciton `quakemigrate.io.core.read_inventory` so that the wiping/substitution of codes is mirrored in the response info:
 - `ignore_network_code`
 - `dummy_network_code`
 - `ignore_location_code`

The dummy network code is checked to ensure it is a two-character string. If not specified it is set to 'XX'.

### Relevant Issues
N/A

## Test cases
- [x] Added the `ignore_network_code=True` kwarg to the `Iceland_Icequake` example; runs successfully but output cut waveforms now have network code 'XX'.
- [x] Attempted to set an invalid network code ('XXX') and this was rejected.
- [x] Set `ignore_location_code=True` after manually editing location code for the input mSEED; runs successfully but output cut waveforms now have location code "" (empty string).
- [x] All examples run without any new warnings
- [x] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.


### Final checklist
- [x] Correct base branch selected?
    - `master` (if a bugfix/patch update)
- [x] All tests still pass.
- [x] Significant changes have been added to `CHANGES.md`.
