### PR TITLE
FIX: Validate all required columns in read_stations header

### DIFF
--- a/quakemigrate/io/core.py
+++ b/quakemigrate/io/core.py
@@ -89,7 +89,8 @@ def read_stations(station_file, **kwargs):
 
     stn_data = pd.read_csv(station_file, **kwargs)
 
-    if ("Latitude" or "Longitude" or "Elevation" or "Name") not in stn_data.columns:
+    required_columns = ("Latitude", "Longitude", "Elevation", "Name")
+    if not all(column in stn_data.columns for column in required_columns):
         raise util.StationFileHeaderException
 
     stn_data["Elevation"] = stn_data["Elevation"].apply(lambda x: -1 * x)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests covering functions in quakemigrate.io.core.
+
+:copyright:
+    2020 - 2021, QuakeMigrate developers.
+:license:
+    GNU General Public License, Version 3
+    (https://www.gnu.org/licenses/gpl-3.0.html)
+
+"""
+
+import os
+import tempfile
+import unittest
+
+import quakemigrate.util as util
+from quakemigrate.io.core import read_stations
+
+
+class TestReadStations(unittest.TestCase):
+    @staticmethod
+    def _write(content):
+        handle, path = tempfile.mkstemp(suffix=".csv")
+        os.close(handle)
+        with open(path, "w") as fid:
+            fid.write(content)
+        return path
+
+    def test_complete_header(self):
+        """A station file with every required column is read successfully."""
+        path = self._write(
+            "Latitude,Longitude,Elevation,Name\n1.0,2.0,3.0,STA1\n"
+        )
+        try:
+            stn_data = read_stations(path)
+        finally:
+            os.remove(path)
+        for column in ("Latitude", "Longitude", "Elevation", "Name"):
+            self.assertIn(column, stn_data.columns)
+        # Elevation is negated (positive-up -> depth) and Name kept as str
+        self.assertEqual(stn_data["Elevation"].iloc[0], -3.0)
+        self.assertEqual(stn_data["Name"].iloc[0], "STA1")
+
+    def test_missing_columns_raise(self):
+        """A station file missing any required column must raise.
+
+        Regression test: the header check was
+        ``("Latitude" or "Longitude" or "Elevation" or "Name") not in
+        stn_data.columns``, which short-circuits to ``"Latitude"`` and so only
+        ever checked for that one column. Files missing Longitude, Elevation or
+        Name slipped through and failed later with a confusing ``KeyError``
+        instead of the intended ``StationFileHeaderException``.
+        """
+        cases = [
+            "Longitude,Elevation,Name\n2.0,3.0,STA1\n",       # no Latitude
+            "Latitude,Elevation,Name\n1.0,3.0,STA1\n",        # no Longitude
+            "Latitude,Longitude,Name\n1.0,2.0,STA1\n",        # no Elevation
+            "Latitude,Longitude,Elevation\n1.0,2.0,3.0\n",    # no Name
+        ]
+        for content in cases:
+            path = self._write(content)
+            try:
+                with self.assertRaises(util.StationFileHeaderException):
+                    read_stations(path)
+            finally:
+                os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

`read_stations` validates the station-file header with:

```python
if ("Latitude" or "Longitude" or "Elevation" or "Name") not in stn_data.columns:
    raise util.StationFileHeaderException
```

Because `or` short-circuits to its first truthy operand, the whole
parenthesised expression evaluates to the constant string `"Latitude"`, so
the check is really just `if "Latitude" not in stn_data.columns:`. Only the
**Latitude** column is ever required — a station file missing `Longitude`,
`Elevation` or `Name` slips through validation and then fails later with a
confusing `KeyError` (e.g. `KeyError: 'Elevation'` from the elevation-negation
line, or a cryptic pandas `astype` error for a missing `Name`) instead of the
intended, actionable `StationFileHeaderException`.

The docstring and the exception message ("use: Latitude, Longitude, Elevation,
Name") show all four columns were always meant to be required, so this is a
straightforward bug, not a design choice.

### Fix

Check each required column explicitly:

```python
required_columns = ("Latitude", "Longitude", "Elevation", "Name")
if not all(column in stn_data.columns for column in required_columns):
    raise util.StationFileHeaderException
```

### Reproduction / verification

```python
import pandas as pd
from quakemigrate.io.core import read_stations
# header missing "Elevation" and "Name"
open("bad.csv", "w").write("Latitude,Longitude\n1.0,2.0\n")
read_stations("bad.csv")   # before: KeyError: 'Elevation'  /  after: StationFileHeaderException
```

I added `tests/test_io.py` with a `TestReadStations` case covering a complete
header plus each missing-column case. Verified locally (C extension built):

- on current `master` the missing-column test **fails** (no exception raised);
- with this fix it **passes**, and the valid-header test confirms the
  success path (Elevation negated, `Name` coerced to `str`) is unchanged.

### Note on CI / test placement

I placed the test in a new `tests/test_io.py` (the natural home for
`quakemigrate.io.core`). CI in `run_tests.yml` invokes test files explicitly by
name rather than via pytest discovery, so to have CI run this file one line is
needed in the workflow:

```
coverage run --source=quakemigrate --data-file=../.coverage -a test_io.py
```

I couldn't include that workflow change myself, so I've left it for a
maintainer — happy to adjust placement if you'd prefer the test elsewhere.

### Relationship to #243

#243 reworks `read_stations` into an internal `Station` model and would address
this incidentally via its `try/except AttributeError`. As that is a larger,
API-breaking refactor that may not land on the release line imminently, this is
a minimal, backward-compatible fix for the current `master`. Glad to close this
if you'd rather fold it into #243.
